### PR TITLE
Replace @turf/turf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,25 @@
 {
   "name": "geojson-map-fit-mercator",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geojson-map-fit-mercator",
-      "version": "0.0.1",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@mapbox/sphericalmercator": "^2.0.1",
-        "@turf/turf": "^7.2.0",
+        "@turf/bearing": "^7.2.0",
+        "@turf/centroid": "^7.2.0",
+        "@turf/convex": "^7.2.0",
+        "@turf/envelope": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
+        "@turf/length": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@turf/polygon-to-line": "^7.2.0",
+        "@turf/transform-rotate": "^7.2.0",
         "geojson": "^0.5.0"
       },
       "devDependencies": {
@@ -1879,74 +1888,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@turf/along": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.2.0.tgz",
-      "integrity": "sha512-Cf+d2LozABdb0TJoIcJwFKB+qisJY4nMUW9z6PAuZ9UCH7AR//hy2Z06vwYCKFZKP4a7DRPkOMBadQABCyoYuw==",
-      "dependencies": {
-        "@turf/bearing": "^7.2.0",
-        "@turf/destination": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/angle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.2.0.tgz",
-      "integrity": "sha512-b28rs1NO8Dt/MXadFhnpqH7GnEWRsl+xF5JeFtg9+eM/+l/zGrdliPYMZtAj12xn33w22J1X4TRprAI0rruvVQ==",
-      "dependencies": {
-        "@turf/bearing": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/rhumb-bearing": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/area": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.2.0.tgz",
-      "integrity": "sha512-zuTTdQ4eoTI9nSSjerIy4QwgvxqwJVciQJ8tOPuMHbXJ9N/dNjI7bU8tasjhxas/Cx3NE9NxVHtNpYHL0FSzoA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
     "node_modules/@turf/bbox": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.2.0.tgz",
       "integrity": "sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/bbox-clip": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.2.0.tgz",
-      "integrity": "sha512-q6RXTpqeUQAYLAieUL1n3J6ukRGsNVDOqcYtfzaJbPW+0VsAf+1cI16sN700t0sekbeU1DH/RRVAHhpf8+36wA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1958,6 +1907,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.2.0.tgz",
       "integrity": "sha512-Aj4G1GAAy26fmOqMjUk0Z+Lcax5VQ9g1xYDbHLQWXvfTsaueBT+RzdH6XPnZ/seEEnZkio2IxE8V5af/osupgA==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10",
@@ -1971,332 +1921,10 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.2.0.tgz",
       "integrity": "sha512-Jm0Xt3GgHjRrWvBtAGvgfnADLm+4exud2pRlmCYx8zfiKuNXQFkrcTZcOiJOgTfG20Agq28iSh15uta47jSIbg==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/bezier-spline": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.2.0.tgz",
-      "integrity": "sha512-7BPkc3ufYB9KLvcaTpTsnpXzh9DZoENxCS0Ms9XUwuRXw45TpevwUpOsa3atO76iKQ5puHntqFO4zs8IUxBaaA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-clockwise": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.2.0.tgz",
-      "integrity": "sha512-0fJeFSARxy6ealGBM4Gmgpa1o8msQF87p2Dx5V6uSqzT8VPDegX1NSWl4b7QgXczYa9qv7IAABttdWP0K7Q7eQ==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-concave": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.2.0.tgz",
-      "integrity": "sha512-v3dTN04dfO6VqctQj1a+pjDHb6+/Ev90oAR2QjJuAntY4ubhhr7vKeJdk/w+tWNSMKULnYwfe65Du3EOu3/TeA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-contains": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.2.0.tgz",
-      "integrity": "sha512-dgRQm4uVO5XuLee4PLVH7CFQZKdefUBMIXTPITm2oRIDmPLJKHDOFKQTNkGJ73mDKKBR2lmt6eVH3br6OYrEYg==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/boolean-point-on-line": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-crosses": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.2.0.tgz",
-      "integrity": "sha512-9GyM4UUWFKQOoNhHVSfJBf5XbPy8Fxfz9djjJNAnm/IOl8NmFUSwFPAjKlpiMcr6yuaAoc9R/1KokS9/eLqPvA==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/line-intersect": "^7.2.0",
-        "@turf/polygon-to-line": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-disjoint": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.2.0.tgz",
-      "integrity": "sha512-xdz+pYKkLMuqkNeJ6EF/3OdAiJdiHhcHCV0ykX33NIuALKIEpKik0+NdxxNsZsivOW6keKwr61SI+gcVtHYcnQ==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/line-intersect": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/polygon-to-line": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-equal": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.2.0.tgz",
-      "integrity": "sha512-TmjKYLsxXqEmdDtFq3QgX4aSogiISp3/doeEtDOs3NNSR8susOtBEZkmvwO6DLW+g/rgoQJIBR6iVoWiRqkBxw==",
-      "dependencies": {
-        "@turf/clean-coords": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "geojson-equality-ts": "^1.0.2",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-intersects": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.2.0.tgz",
-      "integrity": "sha512-GLRyLQgK3F14drkK5Qi9Mv7Z9VT1bgQUd9a3DB3DACTZWDSwfh8YZUFn/HBwRkK8dDdgNEXaavggQHcPi1k9ow==",
-      "dependencies": {
-        "@turf/boolean-disjoint": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-overlap": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.2.0.tgz",
-      "integrity": "sha512-ieM5qIE4anO+gUHIOvEN7CjyowF+kQ6v20/oNYJCp63TVS6eGMkwgd+I4uMzBXfVW66nVHIXjODdUelU+Xyctw==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/line-intersect": "^7.2.0",
-        "@turf/line-overlap": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "geojson-equality-ts": "^1.0.2",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-parallel": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.2.0.tgz",
-      "integrity": "sha512-iOtuzzff8nmwv05ROkSvyeGLMrfdGkIi+3hyQ+DH4IVyV37vQbqR5oOJ0Nt3Qq1Tjrq9fvF8G3OMdAv3W2kY9w==",
-      "dependencies": {
-        "@turf/clean-coords": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/line-segment": "^7.2.0",
-        "@turf/rhumb-bearing": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-point-in-polygon": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.2.0.tgz",
-      "integrity": "sha512-lvEOjxeXIp+wPXgl9kJA97dqzMfNexjqHou+XHVcfxQgolctoJiRYmcVCWGpiZ9CBf/CJha1KmD1qQoRIsjLaA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "point-in-polygon-hao": "^1.1.0",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-point-on-line": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.2.0.tgz",
-      "integrity": "sha512-H/bXX8+2VYeSyH8JWrOsu8OGmeA9KVZfM7M6U5/fSqGsRHXo9MyYJ94k39A9kcKSwI0aWiMXVD2UFmiWy8423Q==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-touches": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.2.0.tgz",
-      "integrity": "sha512-8qb1CO+cwFATGRGFgTRjzL9aibfsbI91pdiRl7KIEkVdeN/H9k8FDrUA1neY7Yq48IaciuwqjbbojQ16FD9b0w==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/boolean-point-on-line": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-valid": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.2.0.tgz",
-      "integrity": "sha512-xb7gdHN8VV6ivPJh6rPpgxmAEGReiRxqY+QZoEZVGpW2dXcmU1BdY6FA6G/cwvggXAXxJBREoANtEDgp/0ySbA==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/boolean-crosses": "^7.2.0",
-        "@turf/boolean-disjoint": "^7.2.0",
-        "@turf/boolean-overlap": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/boolean-point-on-line": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/line-intersect": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "geojson-polygon-self-intersections": "^1.2.1",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-within": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.2.0.tgz",
-      "integrity": "sha512-zB3AiF59zQZ27Dp1iyhp9mVAKOFHat8RDH45TZhLY8EaqdEPdmLGvwMFCKfLryQcUDQvmzP8xWbtUR82QM5C4g==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/boolean-point-on-line": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/buffer": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.2.0.tgz",
-      "integrity": "sha512-QH1FTr5Mk4z1kpQNztMD8XBOZfpOXPOtlsxaSAj2kDIf5+LquA6HtJjZrjUngnGtzG5+XwcfyRL4ImvLnFjm5Q==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/center": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/jsts": "^2.7.1",
-        "@turf/meta": "^7.2.0",
-        "@turf/projection": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "d3-geo": "1.7.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/center": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.2.0.tgz",
-      "integrity": "sha512-UTNp9abQ2kuyRg5gCIGDNwwEQeF3NbpYsd1Q0KW9lwWuzbLVNn0sOwbxjpNF4J2HtMOs5YVOcqNvYyuoa2XrXw==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/center-mean": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.2.0.tgz",
-      "integrity": "sha512-NaW6IowAooTJ35O198Jw3U4diZ6UZCCeJY+4E+WMLpks3FCxMDSHEfO2QjyOXQMGWZnVxVelqI5x9DdniDbQ+A==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/center-median": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.2.0.tgz",
-      "integrity": "sha512-/CgVyHNG4zAoZpvkl7qBCe4w7giWNVtLyTU5PoIfg1vWM4VpYw+N7kcBBH46bbzvVBn0vhmZr586r543EwdC/A==",
-      "dependencies": {
-        "@turf/center-mean": "^7.2.0",
-        "@turf/centroid": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/center-of-mass": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.2.0.tgz",
-      "integrity": "sha512-ij3pmG61WQPHGTQvOziPOdIgwTMegkYTwIc71Gl7xn4C0vWH6KLDSshCphds9xdWSXt2GbHpUs3tr4XGntHkEQ==",
-      "dependencies": {
-        "@turf/centroid": "^7.2.0",
-        "@turf/convex": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -2308,37 +1936,10 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.2.0.tgz",
       "integrity": "sha512-yJqDSw25T7P48au5KjvYqbDVZ7qVnipziVfZ9aSo7P2/jTE7d4BP21w0/XLi3T/9bry/t9PR1GDDDQljN4KfDw==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/circle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.2.0.tgz",
-      "integrity": "sha512-1AbqBYtXhstrHmnW6jhLwsv7TtmT0mW58Hvl1uZXEDM1NCVXIR50yDipIeQPjrCuJ/Zdg/91gU8+4GuDCAxBGA==",
-      "dependencies": {
-        "@turf/destination": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/clean-coords": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.2.0.tgz",
-      "integrity": "sha512-+5+J1+D7wW7O/RDXn46IfCHuX1gIV1pIAQNSA7lcDbr3HQITZj334C4mOGZLEcGbsiXtlHWZiBtm785Vg8i+QQ==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -2350,107 +1951,10 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.2.0.tgz",
       "integrity": "sha512-JlGUT+/5qoU5jqZmf6NMFIoLDY3O7jKd53Up+zbpJ2vzUp6QdwdNzwrsCeONhynWM13F0MVtPXH4AtdkrgFk4g==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/clusters": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.2.0.tgz",
-      "integrity": "sha512-sKOrIKHHtXAuTKNm2USnEct+6/MrgyzMW42deZ2YG2RRKWGaaxHMFU2Yw71Yk4DqStOqTIBQpIOdrRuSOwbuQw==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/clusters-dbscan": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.2.0.tgz",
-      "integrity": "sha512-VWVUuDreev56g3/BMlnq/81yzczqaz+NVTypN5CigGgP67e+u/CnijphiuhKjtjDd/MzGjXgEWBJc26Y6LYKAw==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "rbush": "^3.0.1",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/clusters-kmeans": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.2.0.tgz",
-      "integrity": "sha512-BxQdK8jc8Mwm9yoClCYkktm4W004uiQGqb/i/6Y7a8xqgJITWDgTu/cy//wOxAWPk4xfe6MThjnqkszWW8JdyQ==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "skmeans": "0.9.7",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/collect": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.2.0.tgz",
-      "integrity": "sha512-zRVGDlYS8Bx/Zz4vnEUyRg4dmqHhkDbW/nIUIJh657YqaMj1SFi4Iv2i9NbcurlUBDJFkpuOhCvvEvAdskJ8UA==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "rbush": "^3.0.1",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/combine": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.2.0.tgz",
-      "integrity": "sha512-VEjm3IvnbMt3IgeRIhCDhhQDbLqCU1/5uN1+j1u6fyA095pCizPThGp4f/COSzC3t1s/iiV+fHuDsB6DihHffQ==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/concave": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.2.0.tgz",
-      "integrity": "sha512-cpaDDlumK762kdadexw5ZAB6g/h2pJdihZ+e65lbQVe3WukJHAANnIEeKsdFCuIyNKrwTz2gWu5ws+OpjP48Yw==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/tin": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "topojson-client": "3.x",
-        "topojson-server": "3.x",
         "tslib": "^2.8.1"
       },
       "funding": {
@@ -2461,6 +1965,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.2.0.tgz",
       "integrity": "sha512-HsgHm+zHRE8yPCE/jBUtWFyaaBmpXcSlyHd5/xsMhSZRImFzRzBibaONWQo7xbKZMISC3Nc6BtUjDi/jEVbqyA==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/meta": "^7.2.0",
@@ -2472,91 +1977,14 @@
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/destination": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.2.0.tgz",
-      "integrity": "sha512-8DUxtOO0Fvrh1xclIUj3d9C5WS20D21F5E+j+X9Q+ju6fcM4huOqTg5ckV1DN2Pg8caABEc5HEZJnGch/5YnYQ==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/difference": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.2.0.tgz",
-      "integrity": "sha512-NHKD1v3s8RX+9lOpvHJg6xRuJOKiY3qxHhz5/FmE0VgGqnCkE7OObqWZ5SsXG+Ckh0aafs5qKhmDdDV/gGi6JA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "polyclip-ts": "^0.16.8",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/dissolve": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.2.0.tgz",
-      "integrity": "sha512-gPG5TE3mAYuZqBut8tPYCKwi4hhx5Cq0ALoQMB9X0hrVtFIKrihrsj98XQM/5pL/UIpAxQfwisQvy6XaOFaoPA==",
-      "dependencies": {
-        "@turf/flatten": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "polyclip-ts": "^0.16.8",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
     "node_modules/@turf/distance": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.2.0.tgz",
       "integrity": "sha512-HBjjXIgEcD/wJYjv7/6OZj5yoky2oUvTtVeIAqO3lL80XRvoYmVg6vkOIu6NswkerwLDDNT9kl7+BFLJoHbh6Q==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/distance-weight": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.2.0.tgz",
-      "integrity": "sha512-NeoyV0fXDH+7nIoNtLjAoH9XL0AS1pmTIyDxEE6LryoDTsqjnuR0YQxIkLCCWDqECoqaOmmBqpeWONjX5BwWCg==",
-      "dependencies": {
-        "@turf/centroid": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/ellipse": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.2.0.tgz",
-      "integrity": "sha512-/Y75S5hE2+xjnTw4dXpQ5r/Y2HPM4xrwkPRCCQRpuuboKdEvm42azYmh7isPnMnBTVcmGb9UmGKj0HHAbiwt1g==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/rhumb-destination": "^7.2.0",
-        "@turf/transform-rotate": "^7.2.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -2568,6 +1996,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.2.0.tgz",
       "integrity": "sha512-xOMtDeNKHwUuDfzQeoSNmdabsP0/IgVDeyzitDe/8j9wTeW+MrKzVbGz7627PT3h6gsO+2nUv5asfKtUbmTyHA==",
+      "license": "MIT",
       "dependencies": {
         "@turf/bbox": "^7.2.0",
         "@turf/bbox-polygon": "^7.2.0",
@@ -2579,136 +2008,13 @@
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/explode": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.2.0.tgz",
-      "integrity": "sha512-jyMXg93J1OI7/65SsLE1k9dfQD3JbcPNMi4/O3QR2Qb3BAs2039oFaSjtW+YqhMqVC4V3ZeKebMcJ8h9sK1n+A==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/flatten": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.2.0.tgz",
-      "integrity": "sha512-q38Qsqr4l7mxp780zSdn0gp/WLBX+sa+gV6qIbDQ1HKCrrPK8QQJmNx7gk1xxEXVot6tq/WyAPysCQdX+kLmMA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/flip": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.2.0.tgz",
-      "integrity": "sha512-X0TQ0U/UYh4tyXdLO5itP1sO2HOvfrZC0fYSWmTfLDM14jEPkEK8PblofznfBygL+pIFtOS2is8FuVcp5XxYpQ==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/geojson-rbush": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.2.0.tgz",
-      "integrity": "sha512-ST8fLv+EwxVkDgsmhHggM0sPk2SfOHTZJkdgMXVFT7gB9o4lF8qk4y4lwvCCGIfFQAp2yv/PN5EaGMEKutk6xw==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "rbush": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/great-circle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.2.0.tgz",
-      "integrity": "sha512-n30OiADyOKHhor0aXNgYfXQYXO3UtsOKmhQsY1D89/Oh1nCIXG/1ZPlLL9ZoaRXXBTUBjh99a+K8029NQbGDhw==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
     "node_modules/@turf/helpers": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
       "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/hex-grid": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.2.0.tgz",
-      "integrity": "sha512-Yo2yUGxrTCQfmcVsSjDt0G3Veg8YD26WRd7etVPD9eirNNgXrIyZkbYA7zVV/qLeRWVmYIKRXg1USWl7ORQOGA==",
-      "dependencies": {
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/intersect": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/interpolate": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.2.0.tgz",
-      "integrity": "sha512-Ifgjm1SEo6XujuSAU6lpRMvoJ1SYTreil1Rf5WsaXj16BQJCedht/4FtWCTNhSWTwEz2motQ1WNrjTCuPG94xA==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/centroid": "^7.2.0",
-        "@turf/clone": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/hex-grid": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/point-grid": "^7.2.0",
-        "@turf/square-grid": "^7.2.0",
-        "@turf/triangle-grid": "^7.2.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/intersect": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.2.0.tgz",
-      "integrity": "sha512-81GMzKS9pKqLPa61qSlFxLFeAC8XbwyCQ9Qv4z6o5skWk1qmMUbEHeMqaGUTEzk+q2XyhZ0sju1FV4iLevQ/aw==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "polyclip-ts": "^0.16.8",
         "tslib": "^2.8.1"
       },
       "funding": {
@@ -2719,64 +2025,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
       "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/isobands": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.2.0.tgz",
-      "integrity": "sha512-lYoHeRieFzpBp29Jh19QcDIb0E+dzo/K5uwZuNga4wxr6heNU0AfkD4ByAHYIXHtvmp4m/JpSKq/2N6h/zvBkg==",
-      "dependencies": {
-        "@turf/area": "^7.2.0",
-        "@turf/bbox": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/explode": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "marchingsquares": "^1.3.3",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/isolines": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.2.0.tgz",
-      "integrity": "sha512-4ZXKxvA/JKkxAXixXhN3UVza5FABsdYgOWXyYm3L5ryTPJVOYTVSSd9A+CAVlv9dZc3YdlsqMqLTXNOOre/kwg==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "marchingsquares": "^1.3.3",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/jsts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
-      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
-      "dependencies": {
-        "jsts": "2.7.1"
-      }
-    },
-    "node_modules/@turf/kinks": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.2.0.tgz",
-      "integrity": "sha512-BtxDxGewJR0Q5WR9HKBSxZhirFX+GEH1rD7/EvgDsHS8e1Y5/vNQQUmXdURjdPa4StzaUBsWRU5T3A356gLbPA==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10",
@@ -2790,185 +2039,12 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.2.0.tgz",
       "integrity": "sha512-LBmYN+iCgVtWNLsckVnpQIJENqIIPO63mogazMp23lrDGfWXu07zZQ9ZinJVO5xYurXNhc/QI2xxoqt2Xw90Ig==",
+      "license": "MIT",
       "dependencies": {
         "@turf/distance": "^7.2.0",
         "@turf/helpers": "^7.2.0",
         "@turf/meta": "^7.2.0",
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-arc": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.2.0.tgz",
-      "integrity": "sha512-kfWzA5oYrTpslTg5fN50G04zSypiYQzjZv3FLjbZkk6kta5fo4JkERKjTeA8x4XNojb+pfmjMBB0yIh2w2dDRw==",
-      "dependencies": {
-        "@turf/circle": "^7.2.0",
-        "@turf/destination": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-chunk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.2.0.tgz",
-      "integrity": "sha512-1ODyL5gETtWSL85MPI0lgp/78vl95M39gpeBxePXyDIqx8geDP9kXfAzctuKdxBoR4JmOVM3NT7Fz7h+IEkC+g==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/length": "^7.2.0",
-        "@turf/line-slice-along": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-intersect": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.2.0.tgz",
-      "integrity": "sha512-GhCJVEkc8EmggNi85EuVLoXF5T5jNVxmhIetwppiVyJzMrwkYAkZSYB3IBFYGUUB9qiNFnTwungVSsBV/S8ZiA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "sweepline-intersections": "^1.5.0",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-offset": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.2.0.tgz",
-      "integrity": "sha512-1+OkYueDCbnEWzbfBh3taVr+3SyM2bal5jfnSEuDiLA6jnlScgr8tn3INo+zwrUkPFZPPAejL1swVyO5TjUahw==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-overlap": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.2.0.tgz",
-      "integrity": "sha512-NNn7/jg53+N10q2Kyt66bEDqN3101iW/1zA5FW7J6UbKApDFkByh+18YZq1of71kS6oUYplP86WkDp16LFpqqw==",
-      "dependencies": {
-        "@turf/boolean-point-on-line": "^7.2.0",
-        "@turf/geojson-rbush": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/line-segment": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/nearest-point-on-line": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "fast-deep-equal": "^3.1.3",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-segment": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.2.0.tgz",
-      "integrity": "sha512-E162rmTF9XjVN4rINJCd15AdQGCBlNqeWN3V0YI1vOUpZFNT2ii4SqEMCcH2d+5EheHLL8BWVwZoOsvHZbvaWA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-slice": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.2.0.tgz",
-      "integrity": "sha512-bHotzZIaU1GPV3RMwttYpDrmcvb3X2i1g/WUttPZWtKrEo2VVAkoYdeZ2aFwtogERYS4quFdJ/TDzAtquBC8WQ==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/nearest-point-on-line": "^7.2.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-slice-along": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.2.0.tgz",
-      "integrity": "sha512-4/gPgP0j5Rp+1prbhXqn7kIH/uZTmSgiubUnn67F8nb9zE+MhbRglhSlRYEZxAVkB7VrGwjyolCwvrROhjHp2A==",
-      "dependencies": {
-        "@turf/bearing": "^7.2.0",
-        "@turf/destination": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-split": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.2.0.tgz",
-      "integrity": "sha512-yJTZR+c8CwoKqdW/aIs+iLbuFwAa3Yan+EOADFQuXXIUGps3bJUXx/38rmowNoZbHyP1np1+OtrotyHu5uBsfQ==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/geojson-rbush": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/line-intersect": "^7.2.0",
-        "@turf/line-segment": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/nearest-point-on-line": "^7.2.0",
-        "@turf/square": "^7.2.0",
-        "@turf/truncate": "^7.2.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-to-polygon": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.2.0.tgz",
-      "integrity": "sha512-iKpJqc7EYc5NvlD4KaqrKKO6mXR7YWO/YwtW60E2FnsF/blnsy9OfAOcilYHgH3S/V/TT0VedC7DW7Kgjy2EIA==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/mask": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.2.0.tgz",
-      "integrity": "sha512-ulJ6dQqXC0wrjIoqFViXuMUdIPX5Q6GPViZ3kGfeVijvlLM7kTFBsZiPQwALSr5nTQg4Ppf3FD0Jmg8IErPrgA==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "polyclip-ts": "^0.16.8",
         "tslib": "^2.8.1"
       },
       "funding": {
@@ -2979,241 +2055,10 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
       "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/midpoint": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.2.0.tgz",
-      "integrity": "sha512-AMn5S9aSrbXdE+Q4Rj+T5nLdpfpn+mfzqIaEKkYI021HC0vb22HyhQHsQbSeX+AWcS4CjD1hFsYVcgKI+5qCfw==",
-      "dependencies": {
-        "@turf/bearing": "^7.2.0",
-        "@turf/destination": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/moran-index": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.2.0.tgz",
-      "integrity": "sha512-Aexh1EmXVPJhApr9grrd120vbalIthcIsQ3OAN2Tqwf+eExHXArJEJqGBo9IZiQbIpFJeftt/OvUvlI8BeO1bA==",
-      "dependencies": {
-        "@turf/distance-weight": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/nearest-neighbor-analysis": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.2.0.tgz",
-      "integrity": "sha512-LmP/crXb7gilgsL0wL9hsygqc537W/a1W5r9XBKJT4SKdqjoXX5APJatJfd3nwXbRIqwDH0cDA9/YyFjBPlKnA==",
-      "dependencies": {
-        "@turf/area": "^7.2.0",
-        "@turf/bbox": "^7.2.0",
-        "@turf/bbox-polygon": "^7.2.0",
-        "@turf/centroid": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/nearest-point": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/nearest-point": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.2.0.tgz",
-      "integrity": "sha512-0wmsqXZ8CGw4QKeZmS+NdjYTqCMC+HXZvM3XAQIU6k6laNLqjad2oS4nDrtcRs/nWDvcj1CR+Io7OiQ6sbpn5Q==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/nearest-point-on-line": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.2.0.tgz",
-      "integrity": "sha512-UOhAeoDPVewBQV+PWg1YTMQcYpJsIqfW5+EuZ5vJl60XwUa0+kqB/eVfSLNXmHENjKKIlEt9Oy9HIDF4VeWmXA==",
-      "dependencies": {
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/nearest-point-to-line": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.2.0.tgz",
-      "integrity": "sha512-EorU7Qj30A7nAjh++KF/eTPDlzwuuV4neBz7tmSTB21HKuXZAR0upJsx6M2X1CSyGEgNsbFB0ivNKIvymRTKBw==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/point-to-line-distance": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/planepoint": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.2.0.tgz",
-      "integrity": "sha512-8Vno01tvi5gThUEKBQ46CmlEKDAwVpkl7stOPFvJYlA1oywjAL4PsmgwjXgleZuFtXQUPBNgv5a42Pf438XP4g==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/point-grid": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.2.0.tgz",
-      "integrity": "sha512-ai7lwBV2FREPW3XiUNohT4opC1hd6+F56qZe20xYhCTkTD9diWjXHiNudQPSmVAUjgMzQGasblQQqvOdL+bJ3Q==",
-      "dependencies": {
-        "@turf/boolean-within": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/point-on-feature": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.2.0.tgz",
-      "integrity": "sha512-ksoYoLO9WtJ/qI8VI9ltF+2ZjLWrAjZNsCsu8F7nyGeCh4I8opjf4qVLytFG44XA2qI5yc6iXDpyv0sshvP82Q==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/center": "^7.2.0",
-        "@turf/explode": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/nearest-point": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/point-to-line-distance": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.2.0.tgz",
-      "integrity": "sha512-fB9Rdnb5w5+t76Gho2dYDkGe20eRrFk8CXi4v1+l1PC8YyLXO+x+l3TrtT8HzL/dVaZeepO6WUIsIw3ditTOPg==",
-      "dependencies": {
-        "@turf/bearing": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/nearest-point-on-line": "^7.2.0",
-        "@turf/projection": "^7.2.0",
-        "@turf/rhumb-bearing": "^7.2.0",
-        "@turf/rhumb-distance": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/point-to-polygon-distance": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-polygon-distance/-/point-to-polygon-distance-7.2.0.tgz",
-      "integrity": "sha512-w+WYuINgTiFjoZemQwOaQSje/8Kq+uqJOynvx7+gleQPHyWQ3VtTodtV4LwzVzXz8Sf7Mngx1Jcp2SNai5CJYA==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/point-to-line-distance": "^7.2.0",
-        "@turf/polygon-to-line": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/points-within-polygon": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.2.0.tgz",
-      "integrity": "sha512-jRKp8/mWNMzA+hKlQhxci97H5nOio9tp14R2SzpvkOt+cswxl+NqTEi1hDd2XetA7tjU0TSoNjEgVY8FfA0S6w==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/polygon-smooth": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.2.0.tgz",
-      "integrity": "sha512-KCp9wF2IEynvGXVhySR8oQ2razKP0zwg99K+fuClP21pSKCFjAPaihPEYq6e8uI/1J7ibjL5++6EMl+LrUTrLg==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/polygon-tangents": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.2.0.tgz",
-      "integrity": "sha512-AHUUPmOjiQDrtP/ODXukHBlUG0C/9I1je7zz50OTfl2ZDOdEqFJQC3RyNELwq07grTXZvg5TS5wYx/Y7nsm47g==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/boolean-within": "^7.2.0",
-        "@turf/explode": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/nearest-point": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -3223,107 +2068,10 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.2.0.tgz",
       "integrity": "sha512-9jeTN3LiJ933I5sd4K0kwkcivOYXXm1emk0dHorwXeSFSHF+nlYesEW3Hd889wb9lZd7/SVLMUeX/h39mX+vCA==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/polygonize": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.2.0.tgz",
-      "integrity": "sha512-U9v+lBhUPDv+nsg/VcScdiqCB59afO6CHDGrwIl2+5i6Ve+/KQKjpTV/R+NqoC1iMXAEq3brY6HY8Ukp/pUWng==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/envelope": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/projection": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.2.0.tgz",
-      "integrity": "sha512-/qke5vJScv8Mu7a+fU3RSChBRijE6EVuFHU3RYihMuYm04Vw8dBMIs0enEpoq0ke/IjSbleIrGQNZIMRX9EwZQ==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/quadrat-analysis": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.2.0.tgz",
-      "integrity": "sha512-fDQh3+ldYNxUqS6QYlvJ7GZLlCeDZR6tD3ikdYtOsSemwW1n/4gm2xcgWJqy3Y0uszBwxc13IGGY7NGEjHA+0w==",
-      "dependencies": {
-        "@turf/area": "^7.2.0",
-        "@turf/bbox": "^7.2.0",
-        "@turf/bbox-polygon": "^7.2.0",
-        "@turf/centroid": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/point-grid": "^7.2.0",
-        "@turf/random": "^7.2.0",
-        "@turf/square-grid": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/random": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.2.0.tgz",
-      "integrity": "sha512-fNXs5mOeXsrirliw84S8UCNkpm4RMNbefPNsuCTfZEXhcr1MuHMzq4JWKb4FweMdN1Yx2l/xcytkO0s71cJ50w==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/rectangle-grid": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.2.0.tgz",
-      "integrity": "sha512-f0o5ifvy0Ml/nHDJzMNcuSk4h11aa3BfvQNnYQhLpuTQu03j/ICZNlzKTLxwjcUqvxADUifty7Z9CX5W6zky4A==",
-      "dependencies": {
-        "@turf/boolean-intersects": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/rewind": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.2.0.tgz",
-      "integrity": "sha512-SZpRAZiZsE22+HVz6pEID+ST25vOdpAMGk5NO1JeqzhpMALIkIGnkG+xnun2CfYHz7wv8/Z0ADiAvei9rkcQYA==",
-      "dependencies": {
-        "@turf/boolean-clockwise": "^7.2.0",
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -3335,6 +2083,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.2.0.tgz",
       "integrity": "sha512-jbdexlrR8X2ZauUciHx3tRwG+BXoMXke4B8p8/IgDlAfIrVdzAxSQN89FMzIKnjJ/kdLjo9bFGvb92bu31Etug==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/invariant": "^7.2.0",
@@ -3349,6 +2098,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.2.0.tgz",
       "integrity": "sha512-U9OLgLAHlH4Wfx3fBZf3jvnkDjdTcfRan5eI7VPV1+fQWkOteATpzkiRjCvSYK575GljVwWBjkKca8LziGWitQ==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/invariant": "^7.2.0",
@@ -3363,165 +2113,10 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.2.0.tgz",
       "integrity": "sha512-NsijTPON1yOc9tirRPEQQuJ5aQi7pREsqchQquaYKbHNWsexZjcDi4wnw2kM3Si4XjmgynT+2f7aXH7FHarHzw==",
+      "license": "MIT",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
         "@turf/invariant": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/sample": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.2.0.tgz",
-      "integrity": "sha512-f+ZbcbQJ9glQ/F26re8LadxO0ORafy298EJZe6XtbctRTJrNus6UNAsl8+GYXFqMnXM22tbTAznnJX3ZiWNorA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/sector": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.2.0.tgz",
-      "integrity": "sha512-zL06MjbbMG4DdpiNz+Q9Ax8jsCekt3R76uxeWShulAGkyDB5smdBOUDoRwxn05UX7l4kKv4Ucq2imQXhxKFd1w==",
-      "dependencies": {
-        "@turf/circle": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/line-arc": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/shortest-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.2.0.tgz",
-      "integrity": "sha512-6fpx8feZ2jMSaeRaFdqFShGWkNb+veUOeyLFSHA/aRD9n/e9F2pWZoRbQWKbKTpcKFJ2FnDEqCZnh/GrcAsqWA==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/bbox-polygon": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/clean-coords": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/transform-scale": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/simplify": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.2.0.tgz",
-      "integrity": "sha512-9YHIfSc8BXQfi5IvEMbCeQYqNch0UawIGwbboJaoV8rodhtk6kKV2wrpXdGqk/6Thg6/RWvChJFKVVTjVrULyQ==",
-      "dependencies": {
-        "@turf/clean-coords": "^7.2.0",
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/square": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.2.0.tgz",
-      "integrity": "sha512-9pMoAGFvqzCDOlO9IRSSBCGXKbl8EwMx6xRRBMKdZgpS0mZgfm9xiptMmx/t1m4qqHIlb/N+3MUF7iMBx6upcA==",
-      "dependencies": {
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/square-grid": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.2.0.tgz",
-      "integrity": "sha512-EmzGXa90hz+tiCOs9wX+Lak6pH0Vghb7QuX6KZej+pmWi3Yz7vdvQLmy/wuN048+wSkD5c8WUo/kTeNDe7GnmA==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/rectangle-grid": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/standard-deviational-ellipse": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.2.0.tgz",
-      "integrity": "sha512-+uC0pR2nRjm90JvMXe/2xOCZsYV2II1ZZ2zmWcBWv6bcFXBspcxk2QfCC3k0bj6jDapELzoQgnn3cG5lbdQV2w==",
-      "dependencies": {
-        "@turf/center-mean": "^7.2.0",
-        "@turf/ellipse": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/points-within-polygon": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/tag": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.2.0.tgz",
-      "integrity": "sha512-TAFvsbp5TCBqXue8ui+CtcLsPZ6NPC88L8Ad6Hb/R6VAi21qe0U42WJHQYXzWmtThoTNwxi+oKSeFbRDsr0FIA==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/tesselate": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.2.0.tgz",
-      "integrity": "sha512-zHGcG85aOJJu1seCm+CYTJ3UempX4Xtyt669vFG6Hbr/Hc7ii6STQ2ysFr7lJwFtU9uyYhphVrrgwIqwglvI/Q==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "earcut": "^2.2.4",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/tin": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.2.0.tgz",
-      "integrity": "sha512-y24Vt3oeE6ZXvyLJamP0Ke02rPlDGE9gF7OFADnR0mT+2uectb0UTIBC3kKzON80TEAlA3GXpKFkCW5Fo/O/Kg==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -3533,6 +2128,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.2.0.tgz",
       "integrity": "sha512-EMCj0Zqy3cF9d3mGRqDlYnX2ZBXe3LgT+piDR0EuF5c5sjuKErcFcaBIsn/lg1gp4xCNZFinkZ3dsFfgGHf6fw==",
+      "license": "MIT",
       "dependencies": {
         "@turf/centroid": "^7.2.0",
         "@turf/clone": "^7.2.0",
@@ -3543,248 +2139,6 @@
         "@turf/rhumb-destination": "^7.2.0",
         "@turf/rhumb-distance": "^7.2.0",
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/transform-scale": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.2.0.tgz",
-      "integrity": "sha512-HYB+pw938eeI8s1/zSWFy6hq+t38fuUaBb0jJsZB1K9zQ1WjEYpPvKF/0//80zNPlyxLv3cOkeBucso3hzI07A==",
-      "dependencies": {
-        "@turf/bbox": "^7.2.0",
-        "@turf/center": "^7.2.0",
-        "@turf/centroid": "^7.2.0",
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/rhumb-bearing": "^7.2.0",
-        "@turf/rhumb-destination": "^7.2.0",
-        "@turf/rhumb-distance": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/transform-translate": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.2.0.tgz",
-      "integrity": "sha512-zAglR8MKCqkzDTjGMIQgbg/f+Q3XcKVzr9cELw5l9CrS1a0VTSDtBZLDm0kWx0ankwtam7ZmI2jXyuQWT8Gbug==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/rhumb-destination": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/triangle-grid": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.2.0.tgz",
-      "integrity": "sha512-4gcAqWKh9hg6PC5nNSb9VWyLgl821cwf9yR9yEzQhEFfwYL/pZONBWCO1cwVF23vSYMSMm+/TwqxH4emxaArfw==",
-      "dependencies": {
-        "@turf/distance": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/intersect": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/truncate": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.2.0.tgz",
-      "integrity": "sha512-jyFzxYbPugK4XjV5V/k6Xr3taBjjvo210IbPHJXw0Zh7Y6sF+hGxeRVtSuZ9VP/6oRyqAOHKUrze+OOkPqBgUg==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/turf": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.2.0.tgz",
-      "integrity": "sha512-G1kKBu4hYgoNoRJgnpJohNuS7bLnoWHZ2G/4wUMym5xOSiYah6carzdTEsMoTsauyi7ilByWHx5UHwbjjCVcBw==",
-      "dependencies": {
-        "@turf/along": "^7.2.0",
-        "@turf/angle": "^7.2.0",
-        "@turf/area": "^7.2.0",
-        "@turf/bbox": "^7.2.0",
-        "@turf/bbox-clip": "^7.2.0",
-        "@turf/bbox-polygon": "^7.2.0",
-        "@turf/bearing": "^7.2.0",
-        "@turf/bezier-spline": "^7.2.0",
-        "@turf/boolean-clockwise": "^7.2.0",
-        "@turf/boolean-concave": "^7.2.0",
-        "@turf/boolean-contains": "^7.2.0",
-        "@turf/boolean-crosses": "^7.2.0",
-        "@turf/boolean-disjoint": "^7.2.0",
-        "@turf/boolean-equal": "^7.2.0",
-        "@turf/boolean-intersects": "^7.2.0",
-        "@turf/boolean-overlap": "^7.2.0",
-        "@turf/boolean-parallel": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/boolean-point-on-line": "^7.2.0",
-        "@turf/boolean-touches": "^7.2.0",
-        "@turf/boolean-valid": "^7.2.0",
-        "@turf/boolean-within": "^7.2.0",
-        "@turf/buffer": "^7.2.0",
-        "@turf/center": "^7.2.0",
-        "@turf/center-mean": "^7.2.0",
-        "@turf/center-median": "^7.2.0",
-        "@turf/center-of-mass": "^7.2.0",
-        "@turf/centroid": "^7.2.0",
-        "@turf/circle": "^7.2.0",
-        "@turf/clean-coords": "^7.2.0",
-        "@turf/clone": "^7.2.0",
-        "@turf/clusters": "^7.2.0",
-        "@turf/clusters-dbscan": "^7.2.0",
-        "@turf/clusters-kmeans": "^7.2.0",
-        "@turf/collect": "^7.2.0",
-        "@turf/combine": "^7.2.0",
-        "@turf/concave": "^7.2.0",
-        "@turf/convex": "^7.2.0",
-        "@turf/destination": "^7.2.0",
-        "@turf/difference": "^7.2.0",
-        "@turf/dissolve": "^7.2.0",
-        "@turf/distance": "^7.2.0",
-        "@turf/distance-weight": "^7.2.0",
-        "@turf/ellipse": "^7.2.0",
-        "@turf/envelope": "^7.2.0",
-        "@turf/explode": "^7.2.0",
-        "@turf/flatten": "^7.2.0",
-        "@turf/flip": "^7.2.0",
-        "@turf/geojson-rbush": "^7.2.0",
-        "@turf/great-circle": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/hex-grid": "^7.2.0",
-        "@turf/interpolate": "^7.2.0",
-        "@turf/intersect": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@turf/isobands": "^7.2.0",
-        "@turf/isolines": "^7.2.0",
-        "@turf/kinks": "^7.2.0",
-        "@turf/length": "^7.2.0",
-        "@turf/line-arc": "^7.2.0",
-        "@turf/line-chunk": "^7.2.0",
-        "@turf/line-intersect": "^7.2.0",
-        "@turf/line-offset": "^7.2.0",
-        "@turf/line-overlap": "^7.2.0",
-        "@turf/line-segment": "^7.2.0",
-        "@turf/line-slice": "^7.2.0",
-        "@turf/line-slice-along": "^7.2.0",
-        "@turf/line-split": "^7.2.0",
-        "@turf/line-to-polygon": "^7.2.0",
-        "@turf/mask": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@turf/midpoint": "^7.2.0",
-        "@turf/moran-index": "^7.2.0",
-        "@turf/nearest-neighbor-analysis": "^7.2.0",
-        "@turf/nearest-point": "^7.2.0",
-        "@turf/nearest-point-on-line": "^7.2.0",
-        "@turf/nearest-point-to-line": "^7.2.0",
-        "@turf/planepoint": "^7.2.0",
-        "@turf/point-grid": "^7.2.0",
-        "@turf/point-on-feature": "^7.2.0",
-        "@turf/point-to-line-distance": "^7.2.0",
-        "@turf/point-to-polygon-distance": "^7.2.0",
-        "@turf/points-within-polygon": "^7.2.0",
-        "@turf/polygon-smooth": "^7.2.0",
-        "@turf/polygon-tangents": "^7.2.0",
-        "@turf/polygon-to-line": "^7.2.0",
-        "@turf/polygonize": "^7.2.0",
-        "@turf/projection": "^7.2.0",
-        "@turf/quadrat-analysis": "^7.2.0",
-        "@turf/random": "^7.2.0",
-        "@turf/rectangle-grid": "^7.2.0",
-        "@turf/rewind": "^7.2.0",
-        "@turf/rhumb-bearing": "^7.2.0",
-        "@turf/rhumb-destination": "^7.2.0",
-        "@turf/rhumb-distance": "^7.2.0",
-        "@turf/sample": "^7.2.0",
-        "@turf/sector": "^7.2.0",
-        "@turf/shortest-path": "^7.2.0",
-        "@turf/simplify": "^7.2.0",
-        "@turf/square": "^7.2.0",
-        "@turf/square-grid": "^7.2.0",
-        "@turf/standard-deviational-ellipse": "^7.2.0",
-        "@turf/tag": "^7.2.0",
-        "@turf/tesselate": "^7.2.0",
-        "@turf/tin": "^7.2.0",
-        "@turf/transform-rotate": "^7.2.0",
-        "@turf/transform-scale": "^7.2.0",
-        "@turf/transform-translate": "^7.2.0",
-        "@turf/triangle-grid": "^7.2.0",
-        "@turf/truncate": "^7.2.0",
-        "@turf/union": "^7.2.0",
-        "@turf/unkink-polygon": "^7.2.0",
-        "@turf/voronoi": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/union": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.2.0.tgz",
-      "integrity": "sha512-Xex/cfKSmH0RZRWSJl4RLlhSmEALVewywiEXcu0aIxNbuZGTcpNoI0h4oLFrE/fUd0iBGFg/EGLXRL3zTfpg6g==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "polyclip-ts": "^0.16.8",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/unkink-polygon": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.2.0.tgz",
-      "integrity": "sha512-dFPfzlIgkEr15z6oXVxTSWshWi51HeITGVFtl1GAKGMtiXJx1uMqnfRsvljqEjaQu/4AzG1QAp3b+EkSklQSiQ==",
-      "dependencies": {
-        "@turf/area": "^7.2.0",
-        "@turf/boolean-point-in-polygon": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/meta": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "rbush": "^3.0.1",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/voronoi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.2.0.tgz",
-      "integrity": "sha512-3K6N0LtJsWTXxPb/5N2qD9e8f4q8+tjTbGV3lE3v8x06iCnNlnuJnqM5NZNPpvgvCatecBkhClO3/3RndE61Fw==",
-      "dependencies": {
-        "@turf/clone": "^7.2.0",
-        "@turf/helpers": "^7.2.0",
-        "@turf/invariant": "^7.2.0",
-        "@types/d3-voronoi": "^1.1.12",
-        "@types/geojson": "^7946.0.10",
-        "d3-voronoi": "1.1.2",
         "tslib": "^2.8.1"
       },
       "funding": {
@@ -3832,11 +2186,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/d3-voronoi": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
-      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw=="
-    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -3865,7 +2214,8 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/geojson-vt": {
       "version": "3.2.5",
@@ -4459,14 +2809,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4683,7 +3025,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -4755,24 +3098,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "node_modules/d3-geo": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
-      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
-      "dependencies": {
-        "d3-array": "1"
-      }
-    },
-    "node_modules/d3-voronoi": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw=="
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -4847,11 +3172,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -5192,7 +3512,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -5437,35 +3758,6 @@
       "integrity": "sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/geojson-equality-ts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
-      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
-      "dependencies": {
-        "@types/geojson": "^7946.0.14"
-      }
-    },
-    "node_modules/geojson-polygon-self-intersections": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.1.tgz",
-      "integrity": "sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==",
-      "dependencies": {
-        "rbush": "^2.0.1"
-      }
-    },
-    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-    },
-    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-      "dependencies": {
-        "quickselect": "^1.0.1"
       }
     },
     "node_modules/geojson-vt": {
@@ -6599,14 +4891,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsts": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
-      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
@@ -6835,11 +5119,6 @@
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/marchingsquares": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/marchingsquares/-/marchingsquares-1.3.3.tgz",
-      "integrity": "sha512-gz6nNQoVK7Lkh2pZulrT4qd4347S/toG9RXH2pyzhLgkL5mLkBoqgv4EvAGXcV0ikDW72n/OQb3Xe8bGagQZCg=="
     },
     "node_modules/markdown-it": {
       "version": "14.1.0",
@@ -7227,28 +5506,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
-    },
-    "node_modules/point-in-polygon-hao": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
-      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
-      }
-    },
-    "node_modules/point-in-polygon-hao/node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
-    },
-    "node_modules/polyclip-ts": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
-      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
-      "dependencies": {
-        "bignumber.js": "^9.1.0",
-        "splaytree-ts": "^1.0.2"
-      }
     },
     "node_modules/potpack": {
       "version": "2.0.0",
@@ -7734,11 +5991,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "node_modules/skmeans": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
-      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7772,11 +6024,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/splaytree-ts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
-      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA=="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -7908,14 +6155,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sweepline-intersections": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
-      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
-      "dependencies": {
-        "tinyqueue": "^2.0.0"
-      }
-    },
     "node_modules/synckit": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
@@ -7995,30 +6234,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/topojson-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
-      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "dependencies": {
-        "commander": "2"
-      },
-      "bin": {
-        "topo2geo": "bin/topo2geo",
-        "topomerge": "bin/topomerge",
-        "topoquantize": "bin/topoquantize"
-      }
-    },
-    "node_modules/topojson-server": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
-      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
-      "dependencies": {
-        "commander": "2"
-      },
-      "bin": {
-        "geo2topo": "bin/geo2topo"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,16 @@
   "homepage": "https://tristandavey.com/geojson-map-fit-mercator",
   "dependencies": {
     "@mapbox/sphericalmercator": "^2.0.1",
-    "@turf/turf": "^7.2.0",
+    "@turf/bearing": "^7.2.0",
+    "@turf/centroid": "^7.2.0",
+    "@turf/convex": "^7.2.0",
+    "@turf/envelope": "^7.2.0",
+    "@turf/helpers": "^7.2.0",
+    "@turf/invariant": "^7.2.0",
+    "@turf/length": "^7.2.0",
+    "@turf/meta": "^7.2.0",
+    "@turf/polygon-to-line": "^7.2.0",
+    "@turf/transform-rotate": "^7.2.0",
     "geojson": "^0.5.0"
   }
 }

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -1,7 +1,7 @@
-import * as turf from '@turf/turf';
 import type { Feature, Polygon, Position } from 'geojson';
 import { SphericalMercator } from '@mapbox/sphericalmercator';
 import { XY, LngLat, mapFitPadding, rectangleOrientation } from './types';
+import { getCoords } from '@turf/invariant';
 
 export function findScreenZoom(
   paddedScreenDimensions: XY,
@@ -12,8 +12,8 @@ export function findScreenZoom(
   merc: SphericalMercator,
 ): number {
   const { shortSide, longSide } = boundingRectangleOrientation;
-  const longSideCoords = turf.getCoords(longSide!);
-  const shortSideCoords = turf.getCoords(shortSide!);
+  const longSideCoords = getCoords(longSide!);
+  const shortSideCoords = getCoords(shortSide!);
 
   // We need to determine the ratio required for the zoom level. To do this we are going to approximate the length
   // of the longest and shortest sides of the polygon in pixels (This doesn't account for projection distortion but is
@@ -43,7 +43,11 @@ export function findScreenZoom(
   return floatZoom ? zoom : Math.floor(zoom);
 }
 
-export function findScreenBearing(boundingRectangleBearing: number, preferredBearing: number, screenRatio: number): number {
+export function findScreenBearing(
+  boundingRectangleBearing: number,
+  preferredBearing: number,
+  screenRatio: number,
+): number {
   let bearing = boundingRectangleBearing;
   // Rotate the bearing by 90 degrees if the screen is wider than it is tall
   if (screenRatio > 1) {
@@ -69,7 +73,7 @@ export function findScreenCenter(
 
   // Use the bounding rectangle's pixel location to calculate the centre of the
   // map. This allows us to account for mercator projection distortion.
-  const coords = turf.getCoords(boundingRectangle);
+  const coords = getCoords(boundingRectangle);
   const uniqCoords = coords[0].reduce((uniq: Position[], coord: [number, number]) => {
     if (!uniq.find((c) => c[0] === coord[0] && c[1] === coord[1])) {
       uniq.push(coord);


### PR DESCRIPTION
While @turf/turf is licensed under the MIT license, two of its component libraries, `@turf/isolines` and `@turf/isobands`, depend on `marchingsquares`, which is licensed under the AGPL 3.0. This renders the full `@turf/turf` library, and any library that depends on it, unusable by most organizations. While I understand and support the goals of the AGPL, it is not an appropriate license for library code. Any code that depends on AGPL code is tainted and unusable because of it. Turf has an [open issue](https://github.com/Turfjs/turf/issues/2723) on this concern, but a resolution has not been determined yet.

Thankfully, in the case of turf, there is a workaround: the component libraries are all published seperately as well, so we as long as there's no dependency on `@turf/isolines` or `@turf/isobands` they can be installed without the virality of the AGPL being a concern.

This pull request does just that.