### PR TITLE
Fix map height in code comment

### DIFF
--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -65,7 +65,7 @@ const { bearing, center, zoom } = mapFitFeatures(
 );
 
 const map = new new maplibregl.Map({
-  container: 'map', // container ID for a 600px by 400px element
+  container: 'map', // container ID for a 600px by 300px element
   style: 'https://demotiles.maplibre.org/style.json',
   center: center, // starting position [lng, lat]
   zoom: zoom, // starting zoom


### PR DESCRIPTION
I guess the height as this is what you have in `mapFitFeatures` call, and the map in the demo is indeed 300px high